### PR TITLE
Fix delegate_impl to generate .await for async fns

### DIFF
--- a/proc_macro/src/delegate_impl/inherent_impl.rs
+++ b/proc_macro/src/delegate_impl/inherent_impl.rs
@@ -272,11 +272,13 @@ fn generate_output(sane: SaneImplInherent) -> Result<TokenStream> {
 
         let inputs = Paren::from((paren_token, all_args));
 
+        let maybe_await = asyncness.as_ref().map(|_| quote! { . await });
+
         functions_tt.extend(quote! {
             #( #attrs )*
             #vis #constness #asyncness #fn_unsafety #abi #fn_token
             #fn_ident #fn_generics #inputs #output #fn_where_clause {
-                #macro_ident ! { self.#fn_ident( #(#invocation_args),* ).into() }
+                #macro_ident ! { self.#fn_ident( #(#invocation_args),* ) #maybe_await .into() }
             }
         });
     }

--- a/proc_macro/src/delegate_impl/trait_impl.rs
+++ b/proc_macro/src/delegate_impl/trait_impl.rs
@@ -388,11 +388,13 @@ fn sane_method_output(method: SaneMethod, macro_ident: &Ident) -> Result<TokenSt
 
     let inputs = Paren::from((paren_token, all_args));
 
+    let maybe_await = asyncness.as_ref().map(|_| quote! { . await });
+
     Ok(quote! {
         #( #attrs )*
         #vis #constness #asyncness #fn_unsafety #abi #fn_token
         #fn_ident #fn_generics #inputs #output #fn_where_clause {
-            #macro_ident ! { self.#fn_ident( #(#invocation_args),* ).into() }
+            #macro_ident ! { self.#fn_ident( #(#invocation_args),* ) #maybe_await .into() }
         }
     })
 }


### PR DESCRIPTION
Currently, async fn in traits when used with `delegate_impl` doesn't generate the delegate calls with .await, causing compile errors since we never return the correct types.

Given

```rs
#[spire_enum::prelude::delegated_enum]
enum MyImpl {
    Variant(VariantImpl)
}

trait AsyncTrait {
    async fn method(&self) -> u32;
}

#[spire_enum::prelude::delegate_impl]
impl AsyncTrait for MyImpl {
    async fn method(&self) -> u32;
}
```

it expands to

```rs
impl AsyncTrait for MyImpl {
    async fn method(&self) -> u32 {
        match self {
            // __var.method() returns impl Future<Output = u32>, we need to await it.
            MyImpl::Variant(__var, ..) => __var.method().into()
        }
    }
}
```

This PR changes the expansion into

```rs
impl AsyncTrait for MyImpl {
    async fn method(&self) -> u32 {
        match self {
            MyImpl::Variant(__var, ..) => __var.method().await.into()
        }
    }
}
```